### PR TITLE
Implement FAI Sporting Code Section 7D, Paragraph 5.2.5

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,9 +39,9 @@
             "args": [
                 "test/work.igc",
                 "scoring=FAI",
-                "debug=true",
-                "trace=763,3439,6002",
-                "verbose=true",
+                "debug=false",
+                "trace=false",
+                "verbose=false",
                 "trim=true"
             ],
             "console": "integratedTerminal"
@@ -69,9 +69,9 @@
             "args": [
                 "test/work.igc",
                 "scoring=XCLeague",
-                "debug=true",
-                "trace=763,3439,6002",
-                "verbose=true",
+                "debug=false",
+                "trace=false",
+                "verbose=false",
                 "trim=true"
             ],
             "console": "integratedTerminal"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,5 @@
 {
+    "[javascript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    }
 }

--- a/scoring-rules.config.js
+++ b/scoring-rules.config.js
@@ -132,7 +132,9 @@ const scoringRules = {
             score: scoring.scoreDistance3Points,
             rounding: round2,
             cardinality: 3,
-            code: 'od'
+            code: 'od',
+            cylinders: 0.4,
+            post: scoring.adjustFAICylinders
         },
         {
             name: 'Free Triangle',
@@ -180,7 +182,9 @@ const scoringRules = {
             closingDistanceFixed: 0.8,
             rounding: round2,
             cardinality: 3,
-            code: 'oar'
+            code: 'oar',
+            cylinders: 0.4,
+            post: scoring.adjustFAICylinders
         }
     ],
     /**

--- a/scoring-rules.config.js
+++ b/scoring-rules.config.js
@@ -144,7 +144,9 @@ const scoringRules = {
             closingDistanceFixed: 0.8,
             rounding: round2,
             cardinality: 3,
-            code: 'tri'
+            code: 'tri',
+            cylinders: 0.4,
+            post: scoring.adjustFAICylinders
         },
         {
             name: 'FAI Triangle',
@@ -157,7 +159,9 @@ const scoringRules = {
             closingDistanceFixed: 0.8,
             rounding: round2,
             cardinality: 3,
-            code: 'fai'
+            code: 'fai',
+            cylinders: 0.4,
+            post: scoring.adjustFAICylinders
         },
     ],
     /**

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import { Box, Point } from './foundation.js';
 import * as geom from './geom.js';
 
 export function closingPenalty(cd, opt) {
@@ -257,7 +258,15 @@ export function boundOutAndReturn1(ranges, boxes, opt) {
         if (!cp)
             return 0;
 
-        return (maxDistance - closingPenalty(cp.d, opt)) * 2 * opt.scoring.multiplier;
+        // The final closing point has to be somewhere in this box
+        const box2 = new Box(
+            (boxes[0].x1 + boxes[2].x1) / 2,
+            (boxes[0].y1 + boxes[2].y1) / 2,
+            (boxes[0].x2 + boxes[2].x2) / 2,
+            (boxes[0].y2 + boxes[2].y2) / 2
+        );
+        const realDistance = geom.maxDistance2Rectangles([boxes[1], box2]);
+        return (realDistance - closingPenalty(cp.d, opt)) * 2 * opt.scoring.multiplier;
     }
 
     // Ranges overlap - bounding is impossible at this stage
@@ -275,16 +284,51 @@ export function scoreOutAndReturn1(tp, opt) {
     if (d > opt.scoring.closingDistance(distance, opt))
         return { score: 0 };
 
-    // Select the better second turn point
-    let tp2;
-    if (tp[1].distanceEarth(tp[0]) > tp[1].distanceEarth(tp[2]))
-        tp2 = tp[0];
-    else
-        tp2 = tp[2];
-
+    // Create the second turn point on the middle of the closing line
+    const tp2 = new Point((tp[0].x + tp[2].x) / 2, (tp[0].y + tp[2].y) / 2);
     const realDistance = tp[1].distanceEarth(tp2);
 
     let score = (realDistance - closingPenalty(d, opt)) * 2 * opt.scoring.multiplier;
 
     return { distance: realDistance, score, tp: [tp[1], tp2], cp: { d, in: tp[0], out: tp[2] } };
+}
+
+// This implements the FAI Sporting Code, Section 7D, Paragraph 5.2.5
+// https://www.fai.org/sites/default/files/civl/documents/sporting_code_s7_d_-_records_and_badges_2022.pdf
+// In igc-xc-score all TPs are lying on the track
+// They are to be transformed to the best possible cylinders
+export function adjustFAICylinders(score, opt) {
+    // Find the centroid of the turnpoints
+    // https://www.mathopenref.com/coordcentroid.html
+    let x = score.tp.reduce((a, t) => a + t.x, 0) / 3;
+    let y = score.tp.reduce((a, t) => a + t.y, 0) / 3;
+    const centroid = new Point(x, y);
+
+    // Move away each TP by 'cylinders' (400m)
+    // https://math.stackexchange.com/questions/175896/finding-a-point-along-a-line-a-certain-distance-away-from-another-point
+    // We can safely assume that the Earth is flat for a distance of 400m
+    // (ie unless we are very near the poles, the curvature will be much less than the 10m declared accuracy)
+    for (const i in score.tp) {
+        const d0 = score.tp[i].distanceEarth(centroid);
+        const t = (d0 + opt.scoring.cylinders) / d0;
+        const xt = (1 - t) * x + t * score.tp[i].x;
+        const yt = (1 - t) * y + t * score.tp[i].y;
+        score.tp[i].x = xt;
+        score.tp[i].y = yt;
+        score.tp[i].r = undefined;
+    }
+
+    switch (opt.scoring.code) {
+    case 'tri':
+    case 'fai':
+        {
+            const d0 = score.tp[0].distanceEarth(score.tp[1]);
+            const d1 = score.tp[1].distanceEarth(score.tp[2]);
+            const d2 = score.tp[2].distanceEarth(score.tp[0]);
+            score.distance = d0 + d1 + d2 - opt.scoring.cylinders * 2 * 3;
+            score.score = (score.distance - closingPenalty(score.cp.d, opt))
+                * opt.scoring.multiplier;
+        }
+        break;
+    }
 }

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -245,8 +245,14 @@ export function scoreOutAndReturn2(tp, opt) {
 
 // Upper limit for an out-and-return with 1 TP (FAI) with a TP somewhere in boxes
 export function boundOutAndReturn1(ranges, boxes, opt) {
-    const maxDistance = Math.max(geom.maxDistance2Rectangles([boxes[1], boxes[0]]),
-        geom.maxDistance2Rectangles([boxes[1], boxes[2]]));
+    // Merge box[0] and box[2]
+    const box2 = new Box(
+        Math.min(boxes[0].x1, boxes[2].x1),
+        Math.min(boxes[0].y1, boxes[2].y1),
+        Math.max(boxes[0].x2, boxes[2].x2),
+        Math.max(boxes[0].y2, boxes[2].y2),
+    );
+    const maxDistance = geom.maxDistance2Rectangles([boxes[1], box2]);
 
     if (maxDistance < (opt.scoring.minDistance || 0))
         return 0;
@@ -259,6 +265,8 @@ export function boundOutAndReturn1(ranges, boxes, opt) {
             return 0;
 
         // The final closing point has to be somewhere in this box
+        // (this is the box containing all the medians of all lines
+        // starting in box[0] and ending in box[2])
         const box2 = new Box(
             (boxes[0].x1 + boxes[2].x1) / 2,
             (boxes[0].y1 + boxes[2].y1) / 2,

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -345,7 +345,7 @@ export function adjustFAICylinders(score, opt) {
         break;
     case 'oar':
         {
-            const realDistance = score.tp[0].distanceEarth(score.tp[1]);
+            const realDistance = score.tp[0].distanceEarth(score.tp[1]) - opt.scoring.cylinders;
             score.score = score.minDistance >= (opt.scoring.minDistance || 0) ?
                 (realDistance - closingPenalty(realDistance, opt)) * 2 * opt.scoring.multiplier : 0;
         }
@@ -356,6 +356,7 @@ export function adjustFAICylinders(score, opt) {
             const all = [score.ep.start, score.tp[0], score.tp[1], score.tp[2], score.ep.finish];
             for (let i = 0; i < all.length - 1; i++)
                 distance += all[i].distanceEarth(all[i + 1]);
+            distance -= opt.scoring.cylinders * 2 * 3 + opt.scoring.cylinders * 2;
             score.score = distance >= (opt.scoring.minDistance || 0) ?
                 distance * opt.scoring.multiplier : 0;
         }

--- a/src/solution.js
+++ b/src/solution.js
@@ -119,7 +119,9 @@ export class Solution {
                     .geojson('tp' + r, {
                         id: 'tp' + r,
                         r: tp[r].r,
-                        timestamp: this.opt.flight.filtered[tp[r].r].timestamp
+                        timestamp: tp[r].r !== undefined ?
+                            this.opt.flight.filtered[tp[r].r].timestamp :
+                            undefined
                     }));
                 // Skip closing the circuit if there are endpoints
                 if (!(this.scoreInfo.ep && r == tp.length - 1))

--- a/src/solver.js
+++ b/src/solver.js
@@ -115,6 +115,9 @@ export default function* solver(flight, _scoringTypes, _config) {
             best.optimal = false;
 
         if (best.optimal) {
+            if (best.opt.scoring.post) {
+                best.opt.scoring.post(best.scoreInfo, best.opt);
+            }
             best.score = best.opt.scoring.rounding(best.score);
             if (best.scoreInfo) {
                 best.scoreInfo.distance = best.opt.scoring.rounding(best.scoreInfo.distance);

--- a/test/test.js
+++ b/test/test.js
@@ -50,8 +50,8 @@ const tests = {
         { file: 'opentri-xcontest-428.31.igc', score: 428.59 }
     ],
     'FAI-OAR': [
-        { file: 'trifai-xcontest-307.57.igc', score: 150.56 },
-        { file: 'out-and-return-record.igc', score: 303.35 }
+        { file: 'trifai-xcontest-307.57.igc', score: 149.77 },
+        { file: 'out-and-return-record.igc', score: 302.56 }
     ],
     XCLeague: [
         { file: 'trifai-xcontest-307.57.igc', score: 426.97 },

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,12 @@ const tests = {
         { file: 'trifai-xcontest-307.57.igc', score: 149.77 },
         { file: 'out-and-return-record.igc', score: 302.56 }
     ],
+    'FAI': [
+        { file: 'trifai-xcontest-189.65.igc', score: 130.78 },
+        { file: 'trifai-xcontest-307.57.igc', score: 264.44 },
+        { file: 'trifai-xcontest-452.21.igc', score: 291.33 },
+        { file: 'fai.igc', score: 228.71 }
+    ],
     XCLeague: [
         { file: 'trifai-xcontest-307.57.igc', score: 426.97 },
         { file: 'out-and-return-record.igc', score: 605.12 },


### PR DESCRIPTION
Ref: https://www.fai.org/sites/default/files/civl/documents/sporting_code_s7_d_-_records_and_badges_2022.pdf
Ref: #94 

All FAI scoring should use turnpoints defined as 400m cylinders and measure distances through the cylinder centers reduced by the cylinder radius