### PR TITLE
#300 reference original index to gps fixes in igc input

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,11 +53,18 @@ interface Scoring {
 	closingDistanceRelative?: number;
 }
 
+/**
+ * A BRecord with an additional property `oR` that is the index of the GPS fix in the original (unfiltered) igc track.
+ */
+interface BRecordWithOr extends BRecord {
+	oR: number;
+}
+
 interface Opt {
 	scoring: Scoring;
 	flight: IGCFile & {
 		/** Filtered GPS fixes when invalid=false, GPS fix number is relative to this array */
-		filtered: BRecord[];
+		filtered: BRecordWithOr[];
 	};
 	/** launch and landing are the indices of the fixes identified as launch and landing **/
 	launch: number;

--- a/src/flight.js
+++ b/src/flight.js
@@ -119,11 +119,19 @@ function detectLaunchLanding(fixes) {
 }
 
 export function analyze(flight, config) {
-    if (!config.invalid)
-        flight.filtered = flight.fixes.filter(x => x.valid)
-            .filter((x, i, a) => i == 0 || a[i-1].timestamp !== x.timestamp);
-    else
-        flight.filtered = flight.fixes.slice(0);
+    if (!config.invalid) {
+        flight.filtered = flight.fixes.reduce((filtered, fix, i, d) => {
+            if (fix.valid && (i === 0 || d[i - 1].timestamp !== fix.timestamp)) {
+                filtered.push({
+                    ...fix,
+                    oR: i,
+                });
+            }
+            return filtered
+        }, []);
+    } else {
+        flight.filtered = flight.fixes.map((f, i) => ({...f, oR: i}));
+    }
     if (flight.filtered.length < 5)
         throw new Error('Flight must contain at least 5 valid GPS fixes, ' +
             `${flight.filtered.length} valid fixes found (out of ${flight.fixes.length})`);

--- a/src/flight.js
+++ b/src/flight.js
@@ -127,7 +127,7 @@ export function analyze(flight, config) {
                     oR: i,
                 });
             }
-            return filtered
+            return filtered;
         }, []);
     } else {
         flight.filtered = flight.fixes.map((f, i) => ({...f, oR: i}));


### PR DESCRIPTION
Adds an additional property "oR" (original index) which refrences the index of the record in the original gps fixes array of the igc input (before filtering)